### PR TITLE
fix: 생일 변경 토스트 위치 조정 및 연동 문구 추가

### DIFF
--- a/src/components/profile/CommonToast.tsx
+++ b/src/components/profile/CommonToast.tsx
@@ -44,20 +44,20 @@ export default function CommonToast({ type, status, onClose }: CommonToastProps)
 
   const message = {
     notification: status === "on"
-      ? "알림 설정이 허용되었습니다."
-      : "알림 설정이 거절되었습니다.",
+      ? "알림 설정이 허용되었습니다"
+      : "알림 설정이 거절되었습니다",
     location: status === "on"
-      ? "위치 권한 요청이 허용되었습니다."
-      : "위치 권한 요청이 거절되었습니다.",
-    password: "비밀번호 변경이 완료되었습니다.",
-    birthday: "생년월일 변경이 완료되었습니다.",
+      ? "위치 권한 요청이 허용되었습니다"
+      : "위치 권한 요청이 거절되었습니다",
+    password: "비밀번호 변경이 완료되었습니다",
+    birthday: "생년월일 변경이 완료되었습니다",
     
   };
 
   return (
     <div
       className={`
-        fixed bottom-20 left-1/2 -translate-x-1/2 w-85 h-16
+        fixed bottom-20 left-1/2 -translate-x-1/2 w-[88%] h-16
         bg-[#006F98] rounded-lg shadow-lg
         px-4 py-3 flex items-center justify-center space-x-3
 

--- a/src/pages/profile/ChangeBirthdayPage.tsx
+++ b/src/pages/profile/ChangeBirthdayPage.tsx
@@ -1,59 +1,30 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { DatePicker, ConfigProvider } from 'antd-mobile';
 import koKR from 'antd-mobile/es/locales/ko-KR';
 import Layout from '../../components/common/Layout';
+import Header from '../../components/common/Header';
+import CommonToast from '../../components/profile/CommonToast';
 
 export default function ChangeBirthdayPage() {
-  const navigate = useNavigate();
+  const initialBirthday = new Date(2003, 4, 19); // 2003년 5월 19일 (월은 0부터 시작)
   const [open, setOpen] = useState(false);
-  const [birthday, setBirthday] = useState<Date | null>(
-    new Date(2003, 4, 19)
-  );
-  const [isModified, setIsModified] = useState(false);
+  const [birthday, setBirthday] = useState<Date | null>(initialBirthday);
+  const [showToast, setShowToast] = useState(false);
 
-  // 🔹 뒤로가기 (state 전달)
-  const handleBack = () => {
-    if (isModified) {
-      navigate('/profile/edit', {
-        state: { toast: 'birthday' },
-      });
-    } else {
-      navigate(-1);
-    }
+  const handleConfirm = (date: Date) => {
+    setOpen(false);
+
+    if (birthday?.getTime() === date.getTime()) return;
+
+    setBirthday(date);
+    setShowToast(true);
   };
 
   return (
     <ConfigProvider locale={koKR}>
       <Layout>
         {/* ✅ 페이지 전용 헤더 */}
-        <header className="fixed top-0 left-1/2 -translate-x-1/2 z-40 bg-white w-[390px] h-[64px] border-b border-gray-200">
-          <div className="relative flex items-center justify-center h-full px-4">
-            <button
-              onClick={handleBack}
-              className="absolute left-4 p-2 rounded-full hover:bg-gray-100 transition-colors"
-              aria-label="뒤로가기"
-            >
-              <svg
-                className="w-8 h-8"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M15 19l-7-7 7-7"
-                />
-              </svg>
-            </button>
-
-            <h1 className="text-xl font-semibold">
-              생년월일 변경
-            </h1>
-          </div>
-        </header>
+        <Header title="생년월일 변경" path="/profile/edit" />
 
         {/* 입력창 */}
         <div className="mt-20 px-[25px]">
@@ -96,14 +67,17 @@ export default function ChangeBirthdayPage() {
           min={new Date(1900, 0, 1)}
           max={new Date()}
           mouseWheel
-          onConfirm={(date) => {
-            setBirthday(date);
-            setIsModified(true);
-            setOpen(false);
-          }}
+          onConfirm={handleConfirm}
           onClose={() => setOpen(false)}
           title="생년월일 선택"
         />
+
+        { showToast && (
+            <CommonToast 
+                type="birthday"
+                onClose={() => setShowToast(false)}
+            />
+        ) }
       </Layout>
     </ConfigProvider>
   );

--- a/src/pages/profile/EditProfilePage.tsx
+++ b/src/pages/profile/EditProfilePage.tsx
@@ -7,7 +7,7 @@ import CommonToast from '../../components/profile/CommonToast';
 import Header from '../../components/common/Header';
 
 type LocationState = {
-  toast?: 'password' | 'birthday';
+  toast?: 'password';
 };
 
 /**
@@ -23,13 +23,13 @@ export default function EditProfilePage() {
   const [phone] = useState('010-1234-5678');
 
     // 토스트 상태 (보일 때만 값 존재)
-  const [toast, setToast] = useState<'password' | 'birthday' | null>(null);
+  const [toast, setToast] = useState<'password' | null>(null);
 
   useEffect(() => {
     const state = location.state as LocationState | null;
 
-    if (state?.toast) {
-      setToast(state.toast);
+    if (state?.toast === 'password') {
+      setToast('password');
 
       // state 제거 (뒤로가기 / 새로고침 중복 방지)
       navigate(location.pathname, { replace: true });
@@ -82,15 +82,21 @@ export default function EditProfilePage() {
 
       {/* 연동 */}
       <div className="flex-1 border-[4px] border-gray-100" />
+      
+      <div className="px-[25px] pt-6 flex items-center gap-3">
+        <span className="border-b border-gray-300 flex-1" />
+        <h2 className="text-[16px] font-medium text-gray-300">연동하기</h2>
+        <span className="border-b border-gray-300 flex-1" />
+      </div>
       <div className="mt-6 mb-12 flex justify-center">
         <img src={iconKakao} className="w-[60px] h-[60px] mx-4" />
         <img src={iconNaver} className="w-[60px] h-[60px] mx-4" />
       </div>
 
-      {/* 토스트 */}
+      {/* 비밀번호 변경 토스트 */}
       {toast && (
         <CommonToast
-          type={toast}
+          type="password"
           onClose={() => setToast(null)}
         />
       )}


### PR DESCRIPTION
## #️⃣ 기능 설명
> 생년월일 변경 완료 토스트의 노출 위치를 조정하고, 개인정보 변경 페이지에 연동 관련 안내 문구를 추가했습니다.

## 🛠️ 작업 상세 내용
- [x] 생년월일 변경 완료 토스트 노출 위치 수정
- [x]  생년월일 변경 시 개인정보 변경 페이지와의 토스트 연동 로직 정리
- [x] 개인정보 변경 페이지 하단에 연동 관련 안내 문구 추가

## 📸 스크린샷 (선택)
<img width="363" height="792" alt="image" src="https://github.com/user-attachments/assets/be516434-049f-4b6e-851a-cf8da36ef346" />
<img width="367" height="797" alt="image" src="https://github.com/user-attachments/assets/de9b7da5-39a2-4972-b56f-46822acbcdbd" />


## 💬 기타(공유사항 to 리뷰어)
