### PR TITLE
feat: 홈 대표 멤버십 스와이프 UI 및 토스트 애니메이션 개선

### DIFF
--- a/src/components/membership/MembershipCard.tsx
+++ b/src/components/membership/MembershipCard.tsx
@@ -1,6 +1,4 @@
-import React from 'react';
-
-interface BarcodeCardProps {
+interface MembershipCardProps {
     brandName: string;
     brandLogo?: string;
     brandColor?: string;
@@ -12,7 +10,7 @@ export default function MembershipCard({
     brandLogo,
     brandColor = '#1F2937', // 기본값: gray-900
     onClick
-}: BarcodeCardProps) {
+}: MembershipCardProps) {
     return (
         <div 
             className="flex flex-col cursor-pointer rounded-[10px] overflow-hidden"

--- a/src/components/membership/MembershipSettingsBottomSheet.tsx
+++ b/src/components/membership/MembershipSettingsBottomSheet.tsx
@@ -44,9 +44,8 @@ export default function MembershipSettingBottomSheet({
         const newValue = !isFavorite;
         setIsFavorite(newValue);
         setShowToast(true);
-        setTimeout(() => setShowToast(false), 1000);
         onSetFavorite?.(newValue);
-        onClose(); // 바텀시트 닫기
+        onClose();
     };
 
     const handleDeleteConfirm = () => {
@@ -131,7 +130,7 @@ export default function MembershipSettingBottomSheet({
             )}
 
             {/* 토스트 */}
-            <FavoriteMembershipToast show={showToast} isFavorite={isFavorite} />
+            {showToast && <FavoriteMembershipToast isFavorite={isFavorite} onClose={() => setShowToast(false)} />}
 
             {/* 삭제 확인 모달 */}
             <MembershipDeleteModal

--- a/src/components/membership/MembershipToast.tsx
+++ b/src/components/membership/MembershipToast.tsx
@@ -1,34 +1,54 @@
-import { Icon } from '@iconify/react';
+import { useEffect, useState } from "react";
+import { Icon } from "@iconify/react";
 
-interface FavoriteMembershipToastProps {
-    show: boolean;
-    isFavorite: boolean;
-}
+type FavoriteMembershipToastProps = {
+  isFavorite: boolean;
+  onClose?: () => void;
+};
 
-export default function FavoriteMembershipToast({ show, isFavorite }: FavoriteMembershipToastProps) {
-    return (
-        <div
-            className={`
-                fixed bottom-24 left-1/2 -translate-x-1/2 z-50
-                transition-all duration-300 ease-in-out
-                ${show ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-2 pointer-events-none'}
-            `}
-        >
-            <div className="flex items-center justify-center gap-[10px] rounded-[10px] w-[343px] h-[65px] bg-[#006F98]">
-                <div className="flex-shrink-0 flex items-center justify-center w-[20px] h-[20px]">
-                    <Icon 
-                        icon="mynaui:star-solid" 
-                        width={20} 
-                        height={20}
-                        className={isFavorite ? 'text-yellow-400' : 'text-gray-300'}
-                    />
-                </div>
-                <span className="text-white text-[16px] font-semibold leading-[20px]">
-                    {isFavorite 
-                        ? '대표 멤버십으로 설정되었습니다' 
-                        : '대표 멤버십이 해제되었습니다'}
-                </span>
-            </div>
+export default function FavoriteMembershipToast({ isFavorite, onClose }: FavoriteMembershipToastProps) {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    setVisible(true);
+
+    const hideTimer = setTimeout(() => {
+      setVisible(false);
+    }, 2000);
+
+    const removeTimer = setTimeout(() => {
+      onClose?.();
+    }, 2300);
+
+    return () => {
+      clearTimeout(hideTimer);
+      clearTimeout(removeTimer);
+    };
+  }, [onClose]);
+
+  return (
+    <div
+      className={`
+        fixed bottom-24 left-1/2 -translate-x-1/2 z-50
+        transition-all duration-300 ease-out
+        ${visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-2'}
+      `}
+    >
+      <div className="flex items-center justify-center gap-[10px] rounded-[10px] w-[343px] h-[65px] bg-[#006F98]">
+        <div className="flex-shrink-0 flex items-center justify-center w-[20px] h-[20px]">
+          <Icon 
+            icon="mynaui:star-solid" 
+            width={20} 
+            height={20}
+            className={isFavorite ? 'text-yellow-400' : 'text-gray-300'}
+          />
         </div>
-    );
+        <span className="text-white text-[16px] font-semibold leading-[20px]">
+          {isFavorite 
+            ? '대표 멤버십으로 설정되었습니다' 
+            : '대표 멤버십이 해제되었습니다'}
+        </span>
+      </div>
+    </div>
+  );
 }

--- a/src/pages/home/WalletPage.tsx
+++ b/src/pages/home/WalletPage.tsx
@@ -14,6 +14,7 @@ import naverIcon from '../../assets/icons/memberships/naver.svg'
 import kakaopayIcon from '../../assets/icons/memberships/kakaopay.svg'
 import FavoriteMembershipCard from '../../components/membership/FavoriteMembershipCard';
 import emptyFavoriteImage from '../../assets/images/empty_favorite.svg';
+import { useState } from 'react';
 
 interface FavoriteMembership {
     id: number;
@@ -24,31 +25,72 @@ interface FavoriteMembership {
 
 export default function WalletPage() {
     const navigate = useNavigate();
+    const [currentSlide, setCurrentSlide] = useState(0);
+    const [touchStart, setTouchStart] = useState(0);
+    const [touchEnd, setTouchEnd] = useState(0);
 
     // TODO: API에서 사용자의 멤버십 목록 가져오기
-    // const favoriteMemberships: FavoriteMembership[] = []; // 멤버십 미추가된 상태
-
     const favoriteMemberships: FavoriteMembership[] = [
-    {
-        id: 1,
-        brandName: 'CJ ONE',
-        brandLogo: cjoneIcon,
-        brandColor: '#1a1a2e',
-    },
-];
+        {
+            id: 1,
+            brandName: 'CJ ONE',
+            brandLogo: cjoneIcon,
+            brandColor: '#1E192A',
+        },
+        {
+            id: 2,
+            brandName: 'KT',
+            brandLogo: ktIcon,
+            brandColor: '#2CBBB6',
+        },
+        {
+            id: 3,
+            brandName: 'SKT',
+            brandLogo: sktIcon,
+            brandColor: '#3617CE',
+        },
+    ];
 
     const membershipList = [
-        { id: 2, brandName: 'CJ ONE', brandLogo: cjoneIcon, brandColor: '#1a1a2e' },
-        { id: 3, brandName: 'KT', brandLogo: ktIcon, brandColor: '#16423C' },
-        { id: 4, brandName: 'SKT', brandLogo: sktIcon, brandColor: '#8B4513' },
-        { id: 5, brandName: 'LG+', brandLogo: uplusIcon, brandColor: '#8B1538' },
-        { id: 6, brandName: '신세계 SSG', brandLogo: ssgIcon, brandColor: '#2F5233' },
-        { id: 7, brandName: 'L.POINT', brandLogo: lpointIcon, brandColor: '#4A5568' },
-        { id: 8, brandName: 'OK 캐쉬백', brandLogo: okcashbagIcon, brandColor: '#8B1538' },
-        { id: 9, brandName: '해피포인트', brandLogo: happypointIcon, brandColor: '#1e3a8a' },
-        { id: 10, brandName: '네이버', brandLogo: naverIcon, brandColor: '#059669' },
-        { id: 11, brandName: '카카오페이', brandLogo: kakaopayIcon, brandColor: '#854d0e' },
+        { id: 2, brandName: 'CJ ONE', brandLogo: cjoneIcon, brandColor: '#1E192A' },
+        { id: 3, brandName: 'KT', brandLogo: ktIcon, brandColor: '#2CBBB6' },
+        { id: 4, brandName: 'SKT', brandLogo: sktIcon, brandColor: '#3617CE' },
+        { id: 5, brandName: 'LG+', brandLogo: uplusIcon, brandColor: '#FF2E98' },
+        { id: 6, brandName: '신세계 SSG', brandLogo: ssgIcon, brandColor: '#902CDF' },
+        { id: 7, brandName: 'L.POINT', brandLogo: lpointIcon, brandColor: '#009BFA' },
+        { id: 8, brandName: 'OK 캐쉬백', brandLogo: okcashbagIcon, brandColor: '#FE0955' },
+        { id: 9, brandName: '해피포인트', brandLogo: happypointIcon, brandColor: '#0D0F71' },
+        { id: 10, brandName: '네이버', brandLogo: naverIcon, brandColor: '#1A033B' },
+        { id: 11, brandName: '카카오페이', brandLogo: kakaopayIcon, brandColor: '#FFEB00' },
     ];
+
+    // 스와이프 최소 거리
+    const minSwipeDistance = 50;
+
+    const handleTouchStart = (e: React.TouchEvent) => {
+        setTouchEnd(0);
+        setTouchStart(e.targetTouches[0].clientX);
+    };
+
+    const handleTouchMove = (e: React.TouchEvent) => {
+        setTouchEnd(e.targetTouches[0].clientX);
+    };
+
+    const handleTouchEnd = () => {
+        if (!touchStart || !touchEnd) return;
+        
+        const distance = touchStart - touchEnd;
+        const isLeftSwipe = distance > minSwipeDistance;
+        const isRightSwipe = distance < -minSwipeDistance;
+
+        if (isLeftSwipe && currentSlide < favoriteMemberships.length - 1) {
+            setCurrentSlide(prev => prev + 1);
+        }
+        
+        if (isRightSwipe && currentSlide > 0) {
+            setCurrentSlide(prev => prev - 1);
+        }
+    };
 
     return (
         <Layout showBottomNav>
@@ -64,14 +106,26 @@ export default function WalletPage() {
                             <h2 className="text-xl font-bold text-gray-900">대표 멤버십</h2>
                         </div>
 
-                        <div className="relative">
+                        <div className="relative overflow-hidden">
                             {favoriteMemberships.length > 0 ? (
-                                <FavoriteMembershipCard
-                                    brandName={favoriteMemberships[0].brandName}
-                                    brandLogo={favoriteMemberships[0].brandLogo}
-                                    brandColor={favoriteMemberships[0].brandColor}
-                                    onClick={() => navigate(`/membership/${favoriteMemberships[0].id}`)}
-                                />
+                                <div
+                                    className="flex transition-transform duration-300 ease-out"
+                                    style={{ transform: `translateX(-${currentSlide * 100}%)` }}
+                                    onTouchStart={handleTouchStart}
+                                    onTouchMove={handleTouchMove}
+                                    onTouchEnd={handleTouchEnd}
+                                >
+                                    {favoriteMemberships.map((membership) => (
+                                        <div key={membership.id} className="w-full flex-shrink-0">
+                                            <FavoriteMembershipCard
+                                                brandName={membership.brandName}
+                                                brandLogo={membership.brandLogo}
+                                                brandColor={membership.brandColor}
+                                                onClick={() => navigate(`/membership/${membership.id}`)}
+                                            />
+                                        </div>
+                                    ))}
+                                </div>
                             ) : (
                                 <div className="w-full h-[208px] bg-gray-200 rounded-[10px] flex items-center justify-center overflow-hidden">
                                     <img 
@@ -84,14 +138,18 @@ export default function WalletPage() {
                         </div>
 
                         {/* 페이지 인디케이터 */}
-                        <div className="flex justify-center gap-2 mt-4">
-                            {[...Array(3)].map((_, index) => (
-                                <div 
-                                    key={index}
-                                    className={`w-1.5 h-1.5 rounded-full transition-colors ${index === 0 ? 'bg-cyan-400' : 'bg-gray-300'}`}
-                                />
-                            ))}
-                        </div>
+                        {favoriteMemberships.length > 0 && (
+                            <div className="flex justify-center gap-2 mt-4">
+                                {favoriteMemberships.map((_, index) => (
+                                    <div 
+                                        key={index}
+                                        className={`w-1.5 h-1.5 rounded-full transition-colors ${
+                                            index === currentSlide ? 'bg-cyan-400' : 'bg-gray-300'
+                                        }`}
+                                    />
+                                ))}
+                            </div>
+                        )}
                     </section>
 
                     <div className="h-8" /> {/* 섹션 간 간격 */}
@@ -112,12 +170,13 @@ export default function WalletPage() {
                             /* 그리드 시스템: 모바일에선 2열 고정 */
                             <div className="grid grid-cols-2 gap-x-3 gap-y-4 w-full justify-items-stretch">
                                 {membershipList.map((membership) => (
-                                        <MembershipTitle
-                                            brandName={membership.brandName}
-                                            brandLogo={membership.brandLogo}
-                                            brandColor={membership.brandColor}
-                                            onClick={() => navigate(`/membership/${membership.id}`)}
-                                        />
+                                    <MembershipTitle
+                                        key={membership.id}
+                                        brandName={membership.brandName}
+                                        brandLogo={membership.brandLogo}
+                                        brandColor={membership.brandColor}
+                                        onClick={() => navigate(`/membership/${membership.id}`)}
+                                    />
                                 ))}
                             </div>
                         ) : (


### PR DESCRIPTION
## #️⃣ 기능 설명
> 홈 화면에서 사용자가 보유한 대표 멤버십 3개를 좌우로 스와이프하여 확인할 수 있도록 개선하고, 대표 멤버십 설정 토스트 애니메이션을 프로필 토스트와 동일한 방식으로 통일하여 일관성을 높였습니다.

## 🛠️ 작업 상세 내용
- [x] 홈 대표 멤버십 영역 스와이프 기능 구현
- [x] 멤버십 스와이프에 따라 인디케이터 상태 연동
- [x] 대표 멤버십 설정 토스트 애니메이션을 프로필 토스트 애니메이션과 동일하게 적용

## 📸 스크린샷 (선택)
https://github.com/user-attachments/assets/d0befeb0-f923-4469-a473-93851ced0729

## 💬 기타(공유사항 to 리뷰어)
