### PR TITLE
refactor: 홈 대시보드 수정

### DIFF
--- a/src/pages/home/WalletPage.tsx
+++ b/src/pages/home/WalletPage.tsx
@@ -202,7 +202,7 @@ export default function WalletPage() {
                                 <h3 className="text-lg font-semibold text-gray-900">등록된 멤버십이 없습니다</h3>
                                 <p className="text-gray-500 text-sm mb-6">첫 멤버십을 등록해보세요</p>
                                 <button
-                                    onClick={() => navigate('/membership/select')}
+                                    onClick={() => navigate('/onboarding/search')}
                                     className="px-8 py-3 bg-blue-600 text-white rounded-xl font-medium active:scale-95 transition-all shadow-md"
                                 >
                                     멤버십 등록하기

--- a/src/pages/home/WalletPage.tsx
+++ b/src/pages/home/WalletPage.tsx
@@ -203,7 +203,7 @@ export default function WalletPage() {
                                 <p className="text-gray-500 text-sm mb-6">첫 멤버십을 등록해보세요</p>
                                 <button
                                     onClick={() => navigate('/onboarding/search')}
-                                    className="px-8 py-3 bg-blue-600 text-white rounded-xl font-medium active:scale-95 transition-all shadow-md"
+                                    className="px-8 py-3 bg-[#00BCD4] text-white rounded-xl font-medium active:scale-95 transition-all"
                                 >
                                     멤버십 등록하기
                                 </button>

--- a/src/pages/home/WalletPage.tsx
+++ b/src/pages/home/WalletPage.tsx
@@ -8,7 +8,7 @@ import emptyFavoriteImage from '../../assets/images/empty_favorite.svg';
 import { dashboardApi } from '../../api/dashboard';
 import type { MainMembership, MembershipSummary } from '../../api/dashboard';
 
-// 브랜드 ID → 로컬 아이콘/컬러 매핑 (logoUrl이 없거나 로딩 실패 시 fallback)
+// 브랜드 ID → 로컬 아이콘/컬러 매핑
 import cjoneIcon from '../../assets/icons/memberships/cjone.svg';
 import ktIcon from '../../assets/icons/memberships/kt.svg';
 import sktIcon from '../../assets/icons/memberships/skt.svg';
@@ -82,15 +82,15 @@ export default function WalletPage() {
 
     const handleTouchEnd = () => {
         if (!touchStart || !touchEnd) return;
-
+        
         const distance = touchStart - touchEnd;
         const isLeftSwipe = distance > minSwipeDistance;
         const isRightSwipe = distance < -minSwipeDistance;
 
-        if (isLeftSwipe && currentSlide < mainMemberships.length - 1) {
+        if (isLeftSwipe && currentSlide < 2) {
             setCurrentSlide(prev => prev + 1);
         }
-
+        
         if (isRightSwipe && currentSlide > 0) {
             setCurrentSlide(prev => prev - 1);
         }
@@ -108,12 +108,12 @@ export default function WalletPage() {
 
     return (
         <Layout showBottomNav>
-            {/* 1. 전체 컨테이너 */}
+            {/* 1. 전체 컨테이너: app-main 내부에서 스크롤이 가능하도록 설정 */}
             <div className="flex flex-col flex-1 bg-gray-50 overflow-y-auto scrollbar-hide pb-20">
-
-                {/* 2. 섹션별 컨테이너 */}
+                
+                {/* 2. 섹션별 컨테이너: max-width를 주어 태블릿/PC에서도 적절한 너비 유지 */}
                 <div className="w-full max-w-[430px] mx-auto">
-
+                    
                     {/* 대표 멤버십 섹션 */}
                     <section className="px-6 pt-6">
                         <div className="flex items-center justify-between mb-4">
@@ -121,48 +121,51 @@ export default function WalletPage() {
                         </div>
 
                         <div className="relative overflow-hidden">
-                            {mainMemberships.length > 0 ? (
-                                <div
-                                    className="flex transition-transform duration-300 ease-out"
-                                    style={{ transform: `translateX(-${currentSlide * 100}%)` }}
-                                    onTouchStart={handleTouchStart}
-                                    onTouchMove={handleTouchMove}
-                                    onTouchEnd={handleTouchEnd}
-                                >
-                                    {mainMemberships.map((membership) => (
-                                        <div key={membership.userMembershipBrandId} className="w-full flex-shrink-0">
-                                            <FavoriteMembershipCard
-                                                brandName={membership.name}
-                                                brandLogo={getBrandIcon(membership.membershipBrandId, membership.logoUrl)}
-                                                brandColor={getBrandColor(membership.membershipBrandId)}
-                                                onClick={() => navigate(`/membership/${membership.userMembershipBrandId}`)}
+                            <div
+                                className="flex transition-transform duration-300 ease-out"
+                                style={{ transform: `translateX(-${currentSlide * 100}%)` }}
+                                onTouchStart={handleTouchStart}
+                                onTouchMove={handleTouchMove}
+                                onTouchEnd={handleTouchEnd}
+                            >
+                                {/* 대표 멤버십 카드들 */}
+                                {mainMemberships.map((membership) => (
+                                    <div key={membership.userMembershipBrandId} className="w-full flex-shrink-0">
+                                        <FavoriteMembershipCard
+                                            brandName={membership.name}
+                                            brandLogo={getBrandIcon(membership.membershipBrandId, membership.logoUrl)}
+                                            brandColor={getBrandColor(membership.membershipBrandId)}
+                                            onClick={() => navigate(`/membership/${membership.userMembershipBrandId}`)}
+                                        />
+                                    </div>
+                                ))}
+                                
+                                {/* 부족한 슬롯만큼 빈 카드 추가 */}
+                                {Array.from({ length: 3 - mainMemberships.length }).map((_, index) => (
+                                    <div key={`empty-${index}`} className="w-full flex-shrink-0">
+                                        <div className="w-full h-[208px] bg-gray-200 rounded-[10px] flex items-center justify-center overflow-hidden">
+                                            <img 
+                                                src={emptyFavoriteImage} 
+                                                alt="대표 멤버십 미설정" 
+                                                className="w-full h-full object-cover"
                                             />
                                         </div>
-                                    ))}
-                                </div>
-                            ) : (
-                                <div className="w-full h-[208px] bg-gray-200 rounded-[10px] flex items-center justify-center overflow-hidden">
-                                    <img
-                                        src={emptyFavoriteImage}
-                                        alt="대표 멤버십 미설정"
-                                        className="w-full h-full object-cover"
-                                    />
-                                </div>
-                            )}
-                        </div>
-
-                        {/* 페이지 인디케이터 */}
-                        {mainMemberships.length > 1 && (
-                            <div className="flex justify-center gap-2 mt-4">
-                                {mainMemberships.map((_, index) => (
-                                    <div
-                                        key={index}
-                                        className={`w-1.5 h-1.5 rounded-full transition-colors ${index === currentSlide ? 'bg-cyan-400' : 'bg-gray-300'
-                                            }`}
-                                    />
+                                    </div>
                                 ))}
                             </div>
-                        )}
+                        </div>
+
+                        {/* 페이지 인디케이터 - 항상 3개 표시 */}
+                        <div className="flex justify-center gap-2 mt-4">
+                            {[0, 1, 2].map((index) => (
+                                <div 
+                                    key={index}
+                                    className={`w-1.5 h-1.5 rounded-full transition-colors ${
+                                        index === currentSlide ? 'bg-cyan-400' : 'bg-gray-300'
+                                    }`}
+                                />
+                            ))}
+                        </div>
                     </section>
 
                     <div className="h-8" /> {/* 섹션 간 간격 */}
@@ -171,7 +174,7 @@ export default function WalletPage() {
                     <section className="px-6">
                         <div className="flex items-center justify-between mb-4">
                             <h2 className="text-xl font-bold text-gray-900">멤버십 리스트</h2>
-                            <button
+                            <button 
                                 onClick={() => navigate('/search')}
                                 className="p-1 active:scale-90 transition-transform"
                             >
@@ -180,7 +183,7 @@ export default function WalletPage() {
                         </div>
 
                         {memberships.length > 0 ? (
-                            /* 그리드 시스템 */
+                            /* 그리드 시스템: 모바일에선 2열 고정 */
                             <div className="grid grid-cols-2 gap-x-3 gap-y-4 w-full justify-items-stretch">
                                 {memberships.map((membership) => (
                                     <MembershipTitle
@@ -199,8 +202,8 @@ export default function WalletPage() {
                                 <h3 className="text-lg font-semibold text-gray-900">등록된 멤버십이 없습니다</h3>
                                 <p className="text-gray-500 text-sm mb-6">첫 멤버십을 등록해보세요</p>
                                 <button
-                                    onClick={() => navigate('/onboarding/search')}
-                                    className="px-8 py-3 bg-[#00BCD4] text-white rounded-xl font-medium active:scale-95 transition-all shadow-md"
+                                    onClick={() => navigate('/membership/select')}
+                                    className="px-8 py-3 bg-blue-600 text-white rounded-xl font-medium active:scale-95 transition-all shadow-md"
                                 >
                                     멤버십 등록하기
                                 </button>


### PR DESCRIPTION
## #️⃣ 기능 설명
> 대표 멤버십 카드 스와이프 버그 및 UI 복구

## 🛠️ 작업 상세 내용
- [x] 대시보드 UI 복구 (인디케이터 항상 3개로 고정 표시하도록 수정)
- [x] 대표 멤버십 카드 스와이프 동작 복구
- [x] 대표 멤버십 부족 시 빈 슬롯에 emptyFavoriteImage 자동 삽입
- [x] 스와이프 범위를 mainMemberships.length - 1에서 2로 변경하여 항상 3페이지 스와이프 가능하도록 수정

## 📸 스크린샷 (선택)

## 💬 기타(공유사항 to 리뷰어)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI 개선**
  * 대표 멤버십 캐러셀이 항상 일관된 3개 슬롯으로 표시됩니다.
  * 페이지 인디케이터가 항상 3개의 고정된 점으로 표시됩니다.
  * 빈 상태의 카드가 동적 슬롯으로 최대 3개까지 채워져 일관되게 표시됩니다.
  * 좌우 스와이프 동작의 이동 범위가 제한되어 안정성이 향상되었습니다.
  * 멤버십 등록 버튼의 그림자 스타일이 제거되었습니다.
* **레이아웃**
  * 헤더 버튼 레이아웃이 소폭 정리되어 표시가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->